### PR TITLE
fix(canvas_matrix): return when data row is undefined

### DIFF
--- a/src/modules/types/chart/advanced/canvas_matrix/controller.js
+++ b/src/modules/types/chart/advanced/canvas_matrix/controller.js
@@ -68,7 +68,7 @@ define([
 
             controller.setVarFromEvent(name, 'intersect', 'matrix', intersect);
 
-            if (typeof data[keyed[0]] === 'undefined') {
+            if (typeof data[keyed[1]] === 'undefined') {
                 return;
             }
 


### PR DESCRIPTION
No more of the errors
`Uncaught TypeError: Cannot read property '48' of undefined`