### PR TITLE
fix: correct form value update with rerendering option on

### DIFF
--- a/src/modules/types/display/template-twig/view.js
+++ b/src/modules/types/display/template-twig/view.js
@@ -231,7 +231,8 @@ define([
         // fill form should execute when the template exists
         // It doesn't make sense otherwise
         await this.hasTemplate;
-
+        await this.renderPromise;
+        this.fillForm();
         if (
           this.module.getConfigurationCheckbox(
             'formOptions',
@@ -239,10 +240,7 @@ define([
           )
         ) {
           await this.rerender();
-        } else {
-          await this.renderPromise;
         }
-        this.fillForm();
       },
 
       style(value) {


### PR DESCRIPTION

<img width="434" height="68" alt="CleanShot 2025-09-17 at 14 02 52@2x" src="https://github.com/user-attachments/assets/b25fac56-f20a-496a-91f3-7d72a1bbb344" />


Also fixes the "twig-form-timing-on-load" testcase, but with this option on

I'm not sure the option is useful, but at least the bug's not back when it is activated.