### PR TITLE
fix: revert aliases which creates incompatibilities with visualizer-helper

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -57,8 +57,6 @@ require.config({
     sprintf: 'components/sprintf/dist/sprintf.min',
     superagent: 'browserified/superagent/index',
     threejs: 'components/threejs/build/three.min',
-    twig: 'browserified/twig/twig',
-    twig_extended: 'lib/twigjs/twig',
     uri: 'components/uri.js/src',
     'web-animations': 'components/web-animations-js/web-animations.min',
     x2js: 'components/x2js/xml2json.min',

--- a/src/lib/twigjs/twig.js
+++ b/src/lib/twigjs/twig.js
@@ -1,7 +1,7 @@
 'use strict';
 
 define([
-  'twig',
+  'browserified/twig/twig',
   'src/util/typerenderer',
   'src/util/util',
 ], function(Twig, Renderer, Util) {

--- a/src/modules/types/display/template-twig/view.js
+++ b/src/modules/types/display/template-twig/view.js
@@ -3,7 +3,7 @@
 define([
   'jquery',
   'modules/default/defaultview',
-  'twig_extended',
+  'lib/twigjs/twig',
   'src/util/debug',
   'src/util/api',
   'lodash',

--- a/src/modules/types/science/chemistry/periodic_table/view.js
+++ b/src/modules/types/science/chemistry/periodic_table/view.js
@@ -2,7 +2,7 @@
 
 define([
   'modules/default/defaultview',
-  'twig_extended',
+  'lib/twigjs/twig',
   'src/util/debug',
   'src/util/colorbar',
   'src/util/color',

--- a/src/src/util/twig.js
+++ b/src/src/util/twig.js
@@ -1,6 +1,6 @@
 'use strict';
 
-define(['twig_extended', 'src/util/ui', 'src/util/Form'], function (
+define(['lib/twigjs/twig', 'src/util/ui', 'src/util/Form'], function (
   Twig,
   UI,
   Form,

--- a/src/src/util/typerenderer.js
+++ b/src/src/util/typerenderer.js
@@ -443,7 +443,7 @@ define([
 
   functions.object = {};
   functions.object.init = async function () {
-    functions.object.twig = await asyncRequire('twig_extended');
+    functions.object.twig = await asyncRequire('lib/twigjs/twig');
   };
   functions.object.toscreen = function ($element, value, root, options = {}) {
     const { twig, twigVariableName, toJSON } = options;


### PR DESCRIPTION
Requirejs does not like it when the same dependency is loaded directly and via a configured path. We should always use the alias or always use the configured path.

I chose to remove the configured path in order to improve the compatibility with https://github.com/cheminfo-js/visualizer-helper

Here is a view reproducing the issue:

[reproduction.json](https://github.com/user-attachments/files/27471618/reproduction.json)


There can be 2 possible symptoms depending on the order in which dependencies are loaded:

- Require in init script never resolves => "ok" log not printed
- Require in twig module never resolves => Twig module never appears